### PR TITLE
h derivates

### DIFF
--- a/problems/keplertest/problem.c
+++ b/problems/keplertest/problem.c
@@ -36,14 +36,23 @@ int main(int argc, char* argv[]) {
     printf("%f %f %f %f %f %f\n",p.x,p.y,p.z, p.vx,p.vy,p.vz);
     printf("%f %f %f %f %f %f\n",pp.x,pp.y,pp.z, pp.vx,pp.vy,pp.vz);
     
-    
+    { 
     struct reb_particle pv = reb_vary_pal_lambda(1.,sim->particles[1],sim->particles[0]);
     double Delta = 1e-8;
     struct reb_particle ppp = reb_pal_to_particle(1.,sim->particles[0],1e-2,a,lambda+Delta,k,h,ix,iy);
     printf("\n");
     printf("%f %f %f %f %f %f\n",pv.x,pv.y,pv.z, pv.vx,pv.vy,pv.vz);
     printf("%f %f %f %f %f %f\n",(ppp.x-pp.x)/Delta,(ppp.y-pp.y)/Delta,(ppp.z-pp.z)/Delta, (ppp.vx-pp.vx)/Delta,(ppp.vy-pp.vy)/Delta,(ppp.vz-pp.vz)/Delta);
+    }
 
+    {
+    struct reb_particle pv = reb_vary_pal_h(1.,sim->particles[1],sim->particles[0]);
+    double Delta = 1e-8;
+    struct reb_particle ppp = reb_pal_to_particle(1.,sim->particles[0],1e-2,a,lambda,k,h+Delta,ix,iy);
+    printf("\n");
+    printf("%f %f %f %f %f %f\n",pv.x,pv.y,pv.z, pv.vx,pv.vy,pv.vz);
+    printf("%f %f %f %f %f %f\n",(ppp.x-pp.x)/Delta,(ppp.y-pp.y)/Delta,(ppp.z-pp.z)/Delta, (ppp.vx-pp.vx)/Delta,(ppp.vy-pp.vy)/Delta,(ppp.vz-pp.vz)/Delta);
+    }
 
 }
 

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -895,6 +895,7 @@ double reb_tools_M_to_f(double e, double M);
 struct reb_particle reb_pal_to_particle(double G, struct reb_particle primary, double m, double a, double lambda, double k, double h, double ix, double iy);
 void reb_particle_to_pal(double G, struct reb_particle p, struct reb_particle primary, double *a, double* lambda, double* k, double* h, double* ix, double* iy);
 struct reb_particle reb_vary_pal_lambda(double G, struct reb_particle po, struct reb_particle primary);
+struct reb_particle reb_vary_pal_h(double G, struct reb_particle po, struct reb_particle primary);
 
 /**
  * @brief Initialize a particle on an orbit in the xy plane.

--- a/src/tools.c
+++ b/src/tools.c
@@ -952,12 +952,12 @@ struct reb_particle reb_vary_pal_h(double G, struct reb_particle po, struct reb_
     np.z = 0.5*iz*W;
 
     double dq_dh = 1./(1.-q)*(slp-h);
-    double dclp_dh = -1./(1.-q)*(clp*clp);
-    double dslp_dh = -1./(1.-q)*(-slp*clp);
+    double dclp_dh = -1./(1.-q)*(-slp*clp);
+    double dslp_dh = -1./(1.-q)*(clp*clp);
     double an = sqrt(G*(po.m+primary.m)/a);
     double ddxi_dh  = dq_dh*an/((1.-q)*(1.-q))*(-slp+q/(2.-l)*h)
-        + 1./(1.-q)*(-dslp_dh+dq_dh/(2.-l)*h+dl_dh*q/((2.-l)*(2.-l))*h+q/(2.-l));
-    double ddeta_dh = an/((1.-q)*(1.-q)) * dq_dh *(+clp - q/(2.-l)*k)
+                + an/(1.-q)*(-dslp_dh+dq_dh/(2.-l)*h+dl_dh*q/((2.-l)*(2.-l))*h+q/(2.-l));
+    double ddeta_dh = dq_dh*an/((1.-q)*(1.-q))*(+clp-q/(2.-l)*k)
                 + an/(1.-q) * (+dclp_dh - dq_dh/(2.-l)*k-dl_dh*q/((2.-l)*(2.-l))*k);
     double ddW_dh = ddeta_dh*ix-ddxi_dh*iy;
 

--- a/src/tools.c
+++ b/src/tools.c
@@ -928,6 +928,47 @@ struct reb_particle reb_vary_pal_lambda(double G, struct reb_particle po, struct
     return np;
 }
 
+struct reb_particle reb_vary_pal_h(double G, struct reb_particle po, struct reb_particle primary){
+    double a, lambda, k, h, ix, iy;
+    reb_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
+
+    struct reb_particle np = {0.};
+    double p=0.,q=0.;
+    reb_solve_kepler_pal(h, k, lambda, &p, &q);
+
+    double slp = sin(lambda+p);
+    double clp = cos(lambda+p);
+    
+    double l = 1.-sqrt(1.-h*h-k*k);
+    double dl_dh = 1./sqrt(1.-h*h-k*k)*h;
+    double xi = a*clp + p/(2.-l)*h -k;
+    double eta = a*slp - p/(2.-l)*k -h;
+
+    double iz = sqrt(fabs(4.-ix*ix-iy*iy));
+    double W = eta*ix-xi*iy;
+
+    np.x = xi+0.5*iy*W;
+    np.y = eta-0.5*ix*W;
+    np.z = 0.5*iz*W;
+
+    double dq_dh = 1./(1.-q)*(slp-h);
+    double dclp_dh = -1./(1.-q)*(clp*clp);
+    double dslp_dh = -1./(1.-q)*(-slp*clp);
+    double an = sqrt(G*(po.m+primary.m)/a);
+    double ddxi_dh  = dq_dh*an/((1.-q)*(1.-q))*(-slp+q/(2.-l)*h)
+        + 1./(1.-q)*(-dslp_dh+dq_dh/(2.-l)*h+dl_dh*q/((2.-l)*(2.-l))*h+q/(2.-l));
+    double ddeta_dh = an/((1.-q)*(1.-q)) * dq_dh *(+clp - q/(2.-l)*k)
+                + an/(1.-q) * (+dclp_dh - dq_dh/(2.-l)*k-dl_dh*q/((2.-l)*(2.-l))*k);
+    double ddW_dh = ddeta_dh*ix-ddxi_dh*iy;
+
+    np.vx = ddxi_dh+0.5*iy*ddW_dh;
+    np.vy = ddeta_dh-0.5*ix*ddW_dh;
+    np.vz = 0.5*iz*ddW_dh;
+
+
+    return np;
+}
+
 
 
 /**************************************


### PR DESCRIPTION
Rejean, this pull request fixes the bug we had in the derivative for h from this afternoon (it was just a typo). You still need to implement the derivatives for the positions, then the h derivative should be working. 

As we discussed, please implement the first k derivate, as well as all the following 6 second derivates:
- dh_dh
- dk_dk
- dlambda_dlambda
- dh_dk
- dh_dlambda
- dk_dlambda

I'm sorry for pushing a little, but please try to do this as soon as possible so we can run a few tests with the MCMC.